### PR TITLE
Add missing header for std::hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*~
+.DS_STORE
+bazel*

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,7 @@
+new_http_archive(
+    name = "gtest",
+    url = "https://github.com/google/googletest/archive/release-1.7.0.zip",
+    sha256 = "b58cb7547a28b2c718d1e38aee18a3659c9e3ff52440297e965f5edffe34b6d0",
+    build_file = "gtest.BUILD",
+    strip_prefix = "googletest-release-1.7.0",
+)

--- a/dplm17/BUILD
+++ b/dplm17/BUILD
@@ -1,0 +1,11 @@
+cc_library(
+	name = "dplm17",
+	hdrs = [
+	     "dplm17_variant.h",
+	],
+	srcs = [
+	     "dplm17_variant.cpp",
+	],
+	copts = ["-std=c++14"],
+	visibility = ["//visibility:public"],
+)

--- a/dplm17/dplm17_variant.cpp
+++ b/dplm17/dplm17_variant.cpp
@@ -1,1 +1,1 @@
-#include <dplm17_variant.h>
+#include "dplm17_variant.h"

--- a/dplm17/dplm17_variant.h
+++ b/dplm17/dplm17_variant.h
@@ -44,6 +44,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <functional>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/dplm20/BUILD
+++ b/dplm20/BUILD
@@ -1,0 +1,21 @@
+cc_test(
+	name = "dplm20_overload_test",
+	srcs = [
+	     "dplm20_overload.t.cpp",
+	],
+	copts = ["-std=c++14"],
+	deps = [":dplm20", "@gtest//:main"],
+	visibility = ["//visibility:public"],
+)
+
+cc_library(
+	name = "dplm20",
+	hdrs = [
+	     "dplm20_overload.h",
+	],
+	srcs = [
+	     "dplm20_overload.cpp",
+	],
+	copts = ["-std=c++14"],
+	visibility = ["//visibility:public"],
+)

--- a/dplm20/dplm20_overload.cpp
+++ b/dplm20/dplm20_overload.cpp
@@ -1,1 +1,1 @@
-#include <dplm20_overload.h>
+#include "dplm20_overload.h"

--- a/dplm20/dplm20_overload.t.cpp
+++ b/dplm20/dplm20_overload.t.cpp
@@ -1,6 +1,5 @@
-#include <dplm20_overload.h>
-
-#include <gtest/gtest.h>
+#include "dplm20/dplm20_overload.h"
+#include "gtest/gtest.h"
 
 #include <string>
 

--- a/dplp/BUILD
+++ b/dplp/BUILD
@@ -1,0 +1,26 @@
+cc_test(
+    name = "dpl_promise_test",
+    srcs = ["dplp_promise.t.cpp"],
+    deps = [":dplp_promise", "@gtest//:main"],    
+)
+
+cc_library(
+    name = "dplp_promise",
+    srcs = [
+        "dplp_anypromise.cpp",        
+        "dplp_promise.cpp",
+        "dplp_promisestate.cpp",        
+        "dplp_promisestateimp.cpp",
+        "dplp_promisestateimputil.cpp",
+        "dplp_resolver.cpp",
+    ],
+    hdrs = [
+        "dplp_anypromise.h",
+        "dplp_promise.h",
+        "dplp_promisestate.h",
+        "dplp_promisestateimp.h",
+        "dplp_promisestateimputil.h",
+        "dplp_resolver.h",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/dplp/dplp_anypromise.cpp
+++ b/dplp/dplp_anypromise.cpp
@@ -1,4 +1,4 @@
-#include <dplp_anypromise.h>
+#include "dplp/dplp_anypromise.h"
 
 // ----------------------------------------------------------------------------
 // Copyright 2017 Bloomberg Finance L.P.

--- a/gtest.BUILD
+++ b/gtest.BUILD
@@ -1,0 +1,14 @@
+cc_library(
+    name = "main",
+    srcs = glob(
+        ["src/*.cc"],
+        exclude = ["src/gtest-all.cc"]
+    ),
+    hdrs = glob([
+        "include/**/*.h",
+        "src/*.h"
+    ]),
+    linkopts = ["-pthread"],	
+    includes = ["include/"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Does not compile with clang version 4.0.0 (trunk 287636) otherwise.